### PR TITLE
feat/vue-join-profile

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/UserController.java
+++ b/backend/src/main/java/com/blog/backend/controller/UserController.java
@@ -30,9 +30,9 @@ public class UserController {
         return ResponseEntity.ok().body(token);
     }
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ProfileResponse> getProfile(@PathVariable Long userId){
-        ProfileResponse profileResponse = userService.getProfile(userId);
+    @GetMapping("/profile/{username}")
+    public ResponseEntity<ProfileResponse> getProfile(@PathVariable String username){
+        ProfileResponse profileResponse = userService.getProfile(username);
         return ResponseEntity.ok(profileResponse);
     }
 }

--- a/backend/src/main/java/com/blog/backend/domain/repository/FollowRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/FollowRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByUser1AndUser2(User user1, User user2);
+    Long countByUser1(User user);
+    Long countByUser2(User user);
 }

--- a/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    public List<Post> findAllByUser(User user);
-    public List<Post> findAllByPublicStatusTrue();
+    List<Post> findAllByUser(User user);
+    List<Post> findAllByPublicStatusTrue();
+    Long countByUser(User user);
 }

--- a/backend/src/main/java/com/blog/backend/dto/PostDetailResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/PostDetailResponse.java
@@ -17,7 +17,8 @@ public record PostDetailResponse (
     LocalDateTime updatedAt,
     Long likeCount,
     List<CommentResponse> commentsResponse,
-    boolean isLiked
+    boolean isLiked,
+    String profileImageUrl
 )
     {
 }

--- a/backend/src/main/java/com/blog/backend/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/ProfileResponse.java
@@ -11,6 +11,9 @@ public record ProfileResponse(
         String email,
         String bio,
         String profileImageUrl,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Long followerCount,
+        Long followingCount,
+        Long postCount
 ) {
 }

--- a/backend/src/main/java/com/blog/backend/service/PostService.java
+++ b/backend/src/main/java/com/blog/backend/service/PostService.java
@@ -157,6 +157,7 @@ public class PostService {
     public PostDetailResponse getPost(Long postId, String username) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(()-> new PostNotFoundException(postId));
+        User author = post.getUser();
 
         if(!post.isPublicStatus()){
             if(username==null){
@@ -198,6 +199,7 @@ public class PostService {
                 .likeCount(likeCount)
                 .commentsResponse(commentsResponse)
                 .isLiked(isLiked)
+                .profileImageUrl(author.getProfileImage())
                 .build();
     }
 

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -1,6 +1,8 @@
 package com.blog.backend.service;
 
 import com.blog.backend.domain.User;
+import com.blog.backend.domain.repository.FollowRepository;
+import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
 import com.blog.backend.dto.ProfileResponse;
 import com.blog.backend.dto.UserJoinRequest;
@@ -28,6 +30,9 @@ public class UserService {
     private String fileDir;
 
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final PostRepository postRepository;
+
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -72,9 +77,13 @@ public class UserService {
         return jwtUtil.createToken(username);
     }
 
-    public ProfileResponse getProfile(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(()-> new UserNotFoundException("null"));
+    public ProfileResponse getProfile(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(()-> new UserNotFoundException(username));
+
+        Long followingCount = followRepository.countByUser1(user);
+        Long followerCount = followRepository.countByUser2(user);
+        Long postCount = postRepository.countByUser(user);
         return ProfileResponse.builder()
                 .id(user.getId())
                 .username(user.getUsername())
@@ -82,6 +91,9 @@ public class UserService {
                 .bio(user.getBio())
                 .profileImageUrl(user.getProfileImage())
                 .createdAt(user.getCreatedAt())
+                .followerCount(followerCount)
+                .followingCount(followingCount)
+                .postCount(postCount)
                 .build();
     }
 


### PR DESCRIPTION
## 프론트에 필요한 정보를 주기 위해 일부 코드 수정
1. 사용자 프로필을 가져오기 위해 아이디가 아닌 유저네임 사용
2. 유저네임에 팔로워, 팔로잉 수 공개를 위해 ProfileResponse에 필드 추가
3. 글 상세 정보를 얻어올 때 좋아요를 눌렀는지 아닌지 여부 확인할 수 있도록 DTO : PostDetailResponse에 isLiked 추가
4. 글 상세 정보를 얻어올 때 작성자의 프로필 사진 URL을 받아오기 위해 DTO : PostDetailResponse에 profileImageUrl 추가