### PR TITLE
feat/updateProfile

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/UserController.java
+++ b/backend/src/main/java/com/blog/backend/controller/UserController.java
@@ -1,9 +1,6 @@
 package com.blog.backend.controller;
 
-import com.blog.backend.dto.ProfileResponse;
-import com.blog.backend.dto.UserJoinRequest;
-import com.blog.backend.dto.UserLoginRequest;
-import com.blog.backend.dto.UserResponse;
+import com.blog.backend.dto.*;
 import com.blog.backend.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -41,5 +38,15 @@ public class UserController {
         }
         ProfileResponse profileResponse = userService.getProfile(username1, username2);
         return ResponseEntity.ok(profileResponse);
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<UserResponse> updateProfile(
+            @RequestPart(value="userUpdateRequest") UserUpdateRequest userUpdateRequest,
+            @RequestPart(value="profileImage", required = false) MultipartFile multipartFile,
+            Authentication authentication){
+        String username = authentication.getName();
+        UserResponse userResponse = userService.updateProfile(userUpdateRequest, multipartFile, username);
+        return ResponseEntity.ok(userResponse);
     }
 }

--- a/backend/src/main/java/com/blog/backend/domain/User.java
+++ b/backend/src/main/java/com/blog/backend/domain/User.java
@@ -43,4 +43,19 @@ public class User {
         this.bio = bio;
     }
 
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateBio(String bio) {
+        this.bio = bio;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/backend/src/main/java/com/blog/backend/domain/repository/UserRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
+
 }

--- a/backend/src/main/java/com/blog/backend/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/com/blog/backend/dto/UserUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.blog.backend.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserUpdateRequest(
+        String password,
+        String email,
+        String bio
+){
+}

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -7,6 +7,7 @@ import com.blog.backend.domain.repository.UserRepository;
 import com.blog.backend.dto.ProfileResponse;
 import com.blog.backend.dto.UserJoinRequest;
 import com.blog.backend.dto.UserResponse;
+import com.blog.backend.dto.UserUpdateRequest;
 import com.blog.backend.exception.DuplicateEmailException;
 import com.blog.backend.exception.DuplicateUsernameException;
 import com.blog.backend.exception.PasswordNotCorrectException;
@@ -20,6 +21,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 @Service
@@ -132,5 +136,55 @@ public class UserService {
         return null;
     }
 
+    @Transactional
+    public UserResponse updateProfile(UserUpdateRequest userUpdateRequest, MultipartFile multipartFile, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(()-> new UserNotFoundException(username));
 
+        String password = userUpdateRequest.password();
+        String email = userUpdateRequest.email();
+        String bio = userUpdateRequest.bio();
+        String profileImage = null;
+        if(email != null) {
+            userRepository.findByEmail(userUpdateRequest.email())
+                    .ifPresent(u -> {
+                        if(!u.getId().equals(user.getId())) {
+                            throw new DuplicateEmailException(u.getEmail());
+                        }
+                    });
+            user.updateEmail(email);
+        }
+        if(password != null) {
+            user.updatePassword(password);
+        }
+
+        user.updateBio(bio);
+
+        if(multipartFile != null && !multipartFile.isEmpty()){
+            if(user.getProfileImage() != null && !user.getProfileImage().equals("/images/profiles/basic_profile_image.png")){
+                deleteOldProfileImage(user.getProfileImage());
+            }
+            profileImage = imageValidate(multipartFile);
+        }
+
+        if(profileImage != null){
+            user.updateProfileImage(profileImage);
+        }
+
+        return UserResponse.builder()
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .build();
+
+    }
+
+    private void deleteOldProfileImage(String profileImage) {
+        try {
+            String fileName = profileImage.substring(profileImage.lastIndexOf("/") + 1);
+            Path filePath = Paths.get(fileDir + fileName);
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            throw new RuntimeException("예전 프로필 사진 삭제 실패");
+        }
+    }
 }


### PR DESCRIPTION
## 회원 정보 업데이트 기능 구현
1. 기본적으로 Username(아이디)는 변경 불가능
2. 이메일 변경 시 이미 가입되어 있는 유저 중 해당 이메일을 가지는 계정이 있다면 예외처리(단, 본인은 예외) 
3. 변경 요청된 비밀번호가 null이면 수정하지 않고 패스

++ 추후 이메일 중복 확인 기능 추가 예정

Closes #25 