### PR TITLE
refactor/getMyList

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/PostController.java
+++ b/backend/src/main/java/com/blog/backend/controller/PostController.java
@@ -19,13 +19,15 @@ public class PostController {
         this.postService = postService;
     }
 
-    @GetMapping("/my-list")
-    public ResponseEntity<List<PostResponse>> getMyPosts(Authentication authentication){
+    @GetMapping("{targetUsername}/list")
+    public ResponseEntity<List<PostResponse>> getUserPosts(
+            @PathVariable String targetUsername,
+            Authentication authentication){
         String username = null;
         if(authentication != null) {
             username = authentication.getName();
         }
-        List<PostResponse> getPostResponse = postService.getMyPosts(username);
+        List<PostResponse> getPostResponse = postService.getUserPosts(targetUsername, username);
         return ResponseEntity.ok(getPostResponse);
     }
 

--- a/backend/src/main/java/com/blog/backend/controller/UserController.java
+++ b/backend/src/main/java/com/blog/backend/controller/UserController.java
@@ -28,15 +28,15 @@ public class UserController {
         return ResponseEntity.ok().body(token);
     }
 
-    @GetMapping("/profile/{username2}")
+    @GetMapping("/profile/{targetUsername}")
     public ResponseEntity<ProfileResponse> getProfile(
-            @PathVariable String username2,
+            @PathVariable String targetUsername,
             Authentication authentication){
-        String username1 = null;
+        String username = null;
         if(authentication != null) {
-            username1 = authentication.getName();
+            username = authentication.getName();
         }
-        ProfileResponse profileResponse = userService.getProfile(username1, username2);
+        ProfileResponse profileResponse = userService.getProfile(targetUsername, username);
         return ResponseEntity.ok(profileResponse);
     }
 

--- a/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
@@ -11,5 +11,10 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUser(User user);
     List<Post> findAllByPublicStatusTrue();
-    Long countByUser(User user);
+
+    List<Post> findAllByUserAndPublicStatus(User user, boolean publicStatus);
+
+    Long countByUserAndPublicStatus(User user2, boolean b);
+
+    Long countByUser(User targetUser);
 }

--- a/backend/src/main/java/com/blog/backend/service/PostService.java
+++ b/backend/src/main/java/com/blog/backend/service/PostService.java
@@ -86,10 +86,16 @@ public class PostService {
                 .build();
     }
 
-    public List<PostResponse> getMyPosts(String username){
-        User user = userRepository.findByUsername(username)
-                        .orElseThrow(()->new UserNotFoundException(username));
-        List<Post> posts =  postRepository.findAllByUser(user);
+    public List<PostResponse> getUserPosts(String targetUsername, String username){
+        User user = userRepository.findByUsername(targetUsername)
+                        .orElseThrow(()->new UserNotFoundException(targetUsername));
+        List<Post> posts = null;
+        if(targetUsername.equals(username)) {
+            posts = postRepository.findAllByUser(user);
+        }
+        if(!targetUsername.equals(username)){
+            posts = postRepository.findAllByUserAndPublicStatus(user, true);
+        }
         return posts.stream()
                 .map(p-> PostResponse.builder()
                         .id(p.getId())

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -81,27 +81,33 @@ public class UserService {
         return jwtUtil.createToken(username);
     }
 
-    public ProfileResponse getProfile(String username1, String username2) {
+    public ProfileResponse getProfile(String targetUsername, String username) {
 
-        User user2 = userRepository.findByUsername(username2)
-                .orElseThrow(()-> new UserNotFoundException(username2));
+        User targetUser = userRepository.findByUsername(targetUsername)
+                .orElseThrow(()-> new UserNotFoundException(targetUsername));
 
-        Long followingCount = followRepository.countByUser1(user2);
-        Long followerCount = followRepository.countByUser2(user2);
-        Long postCount = postRepository.countByUser(user2);
+        Long followingCount = followRepository.countByUser1(targetUser);
+        Long followerCount = followRepository.countByUser2(targetUser);
+        Long postCount = 0L;
+        if(!targetUsername.equals(username)) {
+            postCount = postRepository.countByUserAndPublicStatus(targetUser, true);
+        }
+        if(targetUsername.equals(username)){
+            postCount = postRepository.countByUser(targetUser);
+        }
         boolean isFollowing = false;
-        if(username1 != null) {
-            User user1 = userRepository.findByUsername(username1)
-                    .orElseThrow(()-> new UserNotFoundException(username1));
-            isFollowing =followRepository.existsByUser1AndUser2(user1, user2);
+        if(username != null) {
+            User user = userRepository.findByUsername(username)
+                    .orElseThrow(()-> new UserNotFoundException(username));
+            isFollowing =followRepository.existsByUser1AndUser2(user, targetUser);
         }
         return ProfileResponse.builder()
-                .id(user2.getId())
-                .username(user2.getUsername())
-                .email(user2.getEmail())
-                .bio(user2.getBio())
-                .profileImageUrl(user2.getProfileImage())
-                .createdAt(user2.getCreatedAt())
+                .id(targetUser.getId())
+                .username(targetUser.getUsername())
+                .email(targetUser.getEmail())
+                .bio(targetUser.getBio())
+                .profileImageUrl(targetUser.getProfileImage())
+                .createdAt(targetUser.getCreatedAt())
                 .followerCount(followerCount)
                 .followingCount(followingCount)
                 .postCount(postCount)

--- a/backend/src/test/java/com/blog/backend/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/PostControllerTest.java
@@ -154,8 +154,8 @@ class PostControllerTest {
     @Test
     @DisplayName("로그인 O, 내 게시글 목록 O")
     @WithMockUser(username = "testUser")
-    void getMyPosts_login_notNull() throws Exception{
-        MvcResult result = mockMvc.perform(get("/api/posts/my-list")
+    void getUserPosts_login_notNull() throws Exception{
+        MvcResult result = mockMvc.perform(get("/api/posts/testUser/list")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
@@ -177,8 +177,8 @@ class PostControllerTest {
     @Test
     @DisplayName("로그인 O, 내 게시글 목록 X")
     @WithMockUser(username = "testUser3")
-    void getMyPosts_login_null() throws Exception{
-        MvcResult result = mockMvc.perform(get("/api/posts/my-list")
+    void getUserPosts_login_null() throws Exception{
+        MvcResult result = mockMvc.perform(get("/api/posts/testUser3/list")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0))
@@ -189,13 +189,12 @@ class PostControllerTest {
 
     @Test
     @DisplayName("로그인 X, 내 게시글 목록")
-    void getMyPosts_notLogin() throws Exception{
-        MvcResult result = mockMvc.perform(get("/api/posts/my-list")
+    void getUserPosts_notLogin() throws Exception{
+        mockMvc.perform(get("/api/posts/testUser/list")
                         .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
+                .andExpect(status().isForbidden())
                 .andReturn();
 
-        System.out.println(pretty(result));
     }
 
     @Test


### PR DESCRIPTION
## 본인의 게시글 조회 수정
1. 본인의 게시글 조회가 아닌 유저네임으로 특정 유저의 게시글 조회하도록 로직 변경
2. 검색한 유저네임과 로그인한 유저의 유저네임이 같을 경우 비밀글까지 같이 조회
3. 검색한 유저네임이 로그인한 유저의 유저네임이 아닌 경우 공개글만 조회
4. 프로필 조회시 본인이라면 비밀글을 포함한 글 개수를, 아니라면 공개글만 포함한 글 개수를 작성글에 표시하도록 수정

Closes #22 