### PR TITLE
refactor : LikeResponse DTO 필드 수정

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/LikeController.java
+++ b/backend/src/main/java/com/blog/backend/controller/LikeController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.blog.backend.dto.LikeResponse;
 import com.blog.backend.service.LikeService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,10 +19,10 @@ public class LikeController {
     private final LikeService likeService;
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deleteLike(
+    public ResponseEntity<LikeResponse> deleteLike(
             @PathVariable Long postId, @AuthenticationPrincipal Long userId) {
 
-        likeService.deleteLike(postId, userId);
-        return ResponseEntity.noContent().build();
+        LikeResponse likeResponse = likeService.deleteLike(postId, userId);
+        return ResponseEntity.ok(likeResponse);
     }
 }

--- a/backend/src/main/java/com/blog/backend/domain/repository/LikeRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/LikeRepository.java
@@ -22,4 +22,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     void removeByUser_IdAndPost_Id(Long userId, Long postId);
 
     boolean existsByPost_IdAndUser_Id(Long postId, Long userId);
+
+    Long countByPost_Id(Long postId);
 }

--- a/backend/src/main/java/com/blog/backend/dto/LikeResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/LikeResponse.java
@@ -3,4 +3,4 @@ package com.blog.backend.dto;
 import lombok.Builder;
 
 @Builder
-public record LikeResponse(Long userId, Long postId) {}
+public record LikeResponse(Long totalCount) {}

--- a/backend/src/main/java/com/blog/backend/service/LikeService.java
+++ b/backend/src/main/java/com/blog/backend/service/LikeService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.dto.LikeResponse;
 import com.blog.backend.exception.AlreadyDeleteException;
 
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,13 @@ public class LikeService {
     private final PostRepository postRepository;
 
     @Transactional
-    public void deleteLike(Long postId, Long userId) {
+    public LikeResponse deleteLike(Long postId, Long userId) {
         if (!likeRepository.existsByUser_IdAndPost_Id(userId, postId)) {
             throw new AlreadyDeleteException();
         }
         likeRepository.removeByUser_IdAndPost_Id(userId, postId);
+        Long likeCount = likeRepository.countByPost_Id(postId);
+
+        return LikeResponse.builder().totalCount(likeCount).build();
     }
 }

--- a/backend/src/main/java/com/blog/backend/service/PostService.java
+++ b/backend/src/main/java/com/blog/backend/service/PostService.java
@@ -1,16 +1,14 @@
 package com.blog.backend.service;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.blog.backend.domain.*;
 import com.blog.backend.domain.repository.*;
 import com.blog.backend.dto.*;
 import com.blog.backend.exception.*;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -296,7 +294,7 @@ public class PostService {
         Like like = Like.builder().post(post).user(user).build();
 
         likeRepository.save(like);
-
-        return LikeResponse.builder().userId(userId).postId(postId).build();
+        Long likeCount = likeRepository.countByPost(post);
+        return LikeResponse.builder().totalCount(likeCount).build();
     }
 }

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -1,5 +1,20 @@
 package com.blog.backend.service;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.blog.backend.domain.Post;
 import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.FollowRepository;
@@ -9,21 +24,8 @@ import com.blog.backend.domain.repository.UserRepository;
 import com.blog.backend.dto.*;
 import com.blog.backend.exception.DuplicateEmailException;
 import com.blog.backend.exception.UserNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
- 사용자가 좋아요를 누르거나 좋아요를 취소할 때 반환받는 LikeResponse DTO에서 사용하지 않던 필드 userId, postId를 삭제하고, 해당 글의 전체 좋아요 개수인 totalCount를 추가함