### PR TITLE
refactor : 유저의 글정보 조회시 프로필 사진 나오도록 변경

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/CategoryController.java
+++ b/backend/src/main/java/com/blog/backend/controller/CategoryController.java
@@ -1,9 +1,7 @@
 package com.blog.backend.controller;
 
-import com.blog.backend.dto.CategoryResponse;
-import com.blog.backend.dto.PostResponse;
-import com.blog.backend.service.CategoryService;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +9,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.blog.backend.dto.CategoryResponse;
+import com.blog.backend.dto.PostResponse;
+import com.blog.backend.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/blog/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/blog/backend/service/CategoryService.java
@@ -1,5 +1,10 @@
 package com.blog.backend.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.blog.backend.domain.Category;
 import com.blog.backend.domain.Post;
 import com.blog.backend.domain.repository.CategoryRepository;
@@ -8,11 +13,8 @@ import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.dto.CategoryResponse;
 import com.blog.backend.dto.PostResponse;
 import com.blog.backend.exception.CategoryNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -1,20 +1,5 @@
 package com.blog.backend.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.blog.backend.domain.Post;
 import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.FollowRepository;
@@ -24,8 +9,21 @@ import com.blog.backend.domain.repository.UserRepository;
 import com.blog.backend.dto.*;
 import com.blog.backend.exception.DuplicateEmailException;
 import com.blog.backend.exception.UserNotFoundException;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -194,6 +192,7 @@ public class UserService {
                 .map(
                         p ->
                                 PostResponse.builder()
+                                        .profileImageUrl(p.getProfileImage())
                                         .id(p.getId())
                                         .title(p.getTitle())
                                         .content(p.getContent())


### PR DESCRIPTION
- 팔로잉 유저들의 글을 보는 기능은 이미 기존에 있는 api 들을 활용하여 프론트에서 충분히 보여줄 수 있음
- 특정 사용자의 글을 조회하는 과정에서 누락된 profileImageUrl을 추가하여 글 정보 조회시 작성자의 프로필 사진을 함께 볼 수 있도록 수정