### PR TITLE
refactor : 카테고리 리스트 반환 로직을 유저 서비스에서 처리하도록 수정

### DIFF
--- a/backend/src/main/java/com/blog/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/blog/backend/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                                 HttpMethod.GET,
                                                 "/api/categories/{categoryName}/posts")
                                         .permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/api/categories/list")
+                                        .permitAll()
                                         .requestMatchers(
                                                 "/v3/api-docs/**",
                                                 "/swagger-ui/**",

--- a/backend/src/main/java/com/blog/backend/controller/CategoryController.java
+++ b/backend/src/main/java/com/blog/backend/controller/CategoryController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.blog.backend.dto.CategoryResponse;
 import com.blog.backend.dto.PostResponse;
 import com.blog.backend.service.CategoryService;
 
@@ -20,14 +19,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/categories/")
 public class CategoryController {
     private final CategoryService categoryService;
-
-    @GetMapping("/list")
-    public ResponseEntity<List<CategoryResponse>> getCategoryList(
-            @AuthenticationPrincipal Long userId) {
-
-        List<CategoryResponse> categoryResponses = categoryService.getCategoryList(userId);
-        return ResponseEntity.ok(categoryResponses);
-    }
 
     @GetMapping("/{categoryId}/posts")
     public ResponseEntity<List<PostResponse>> getCategoryPosts(

--- a/backend/src/main/java/com/blog/backend/controller/UserController.java
+++ b/backend/src/main/java/com/blog/backend/controller/UserController.java
@@ -61,4 +61,12 @@ public class UserController {
         List<PostResponse> getPostResponse = userService.getUserPosts(userId, loginUserId);
         return ResponseEntity.ok(getPostResponse);
     }
+
+    @GetMapping("{userId}/categories")
+    public ResponseEntity<List<CategoryResponse>> getCategoryList(
+            @PathVariable Long userId, @AuthenticationPrincipal Long loginUserId) {
+
+        List<CategoryResponse> categoryResponses = userService.getCategoryList(userId, loginUserId);
+        return ResponseEntity.ok(categoryResponses);
+    }
 }

--- a/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.blog.backend.domain.Category;
 import com.blog.backend.domain.Post;
 
 @Repository
@@ -22,4 +23,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByCategory_IdAndPublicStatus(Long categoryId, boolean b);
 
     List<Post> findAllByCategory_Id(Long categoryId);
+
+    Long countByCategory(Category category);
+
+    Long countByCategoryAndPublicStatus(Category category, boolean b);
 }

--- a/backend/src/main/java/com/blog/backend/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/CategoryResponse.java
@@ -3,4 +3,4 @@ package com.blog.backend.dto;
 import lombok.Builder;
 
 @Builder
-public record CategoryResponse(Long id, String categoryName) {}
+public record CategoryResponse(Long id, String categoryName, Long postsCount) {}

--- a/backend/src/main/java/com/blog/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/blog/backend/service/CategoryService.java
@@ -10,7 +10,6 @@ import com.blog.backend.domain.Post;
 import com.blog.backend.domain.repository.CategoryRepository;
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
-import com.blog.backend.dto.CategoryResponse;
 import com.blog.backend.dto.PostResponse;
 import com.blog.backend.exception.CategoryNotFoundException;
 
@@ -23,18 +22,6 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
-
-    public List<CategoryResponse> getCategoryList(Long userId) {
-
-        return categoryRepository.findAllByUser_Id(userId).stream()
-                .map(
-                        category ->
-                                CategoryResponse.builder()
-                                        .id(category.getId())
-                                        .categoryName(category.getName())
-                                        .build())
-                .toList();
-    }
 
     public List<PostResponse> getCategoryPosts(Long categoryId, Long userId) {
         Category category =

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -2,10 +2,7 @@ package com.blog.backend.service;
 
 import com.blog.backend.domain.Post;
 import com.blog.backend.domain.User;
-import com.blog.backend.domain.repository.FollowRepository;
-import com.blog.backend.domain.repository.LikeRepository;
-import com.blog.backend.domain.repository.PostRepository;
-import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.domain.repository.*;
 import com.blog.backend.dto.*;
 import com.blog.backend.exception.DuplicateEmailException;
 import com.blog.backend.exception.UserNotFoundException;
@@ -38,6 +35,7 @@ public class UserService {
     private final FollowRepository followRepository;
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
+    private final CategoryRepository categoryRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
     public ProfileBasicResponse getProfileBasic(Long userId) {
@@ -202,6 +200,37 @@ public class UserService {
                                         .createdAt(p.getCreatedAt())
                                         .likeCount(likeRepository.countByPost(p))
                                         .build())
+                .toList();
+    }
+
+    public List<CategoryResponse> getCategoryList(Long userId, Long loginUserId) {
+        if (userId.equals(loginUserId)) {
+            return categoryRepository.findAllByUser_Id(userId).stream()
+                    .map(
+                            category ->
+                                    CategoryResponse.builder()
+                                            .postsCount(postRepository.countByCategory(category))
+                                            .id(category.getId())
+                                            .categoryName(category.getName())
+                                            .build())
+                    .toList();
+        }
+
+        return categoryRepository.findAllByUser_Id(userId).stream()
+                .map(
+                        category -> {
+                            Long postsCount =
+                                    postRepository.countByCategoryAndPublicStatus(category, true);
+                            if (postsCount > 0) {
+                                return CategoryResponse.builder()
+                                        .postsCount(postsCount)
+                                        .id(category.getId())
+                                        .categoryName(category.getName())
+                                        .build();
+                            }
+                            return null;
+                        })
+                .filter(java.util.Objects::nonNull)
                 .toList();
     }
 }


### PR DESCRIPTION
- 기존에 카테고리 리스트는 본인이 글을 작성할 때 본인의 카테고리 종류를 확인하는 용도로 사용했으나 이제는 글 목록을 볼때 인덱스로 활용하기 위해 카테고리 목록을 뽑게 되어 코드를 수정하였음
- 유저의 아이디를 받아서 카테고리 리스트를 반환하는 로직을 유저 컨트롤러와 유저 서비스에서 처리하도록 수정
- 로그인, 비로그인 그리고 본인인지 아닌지를 파악하여 반환값을 달리 하도록(비밀글) 서비스 로직 수정(42번 이슈) 
Closes #42
Closes #43