### PR TITLE
feature : 글 정렬 기준 추가

### DIFF
--- a/backend/src/main/java/com/blog/backend/controller/PostController.java
+++ b/backend/src/main/java/com/blog/backend/controller/PostController.java
@@ -1,7 +1,11 @@
 package com.blog.backend.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -51,8 +55,12 @@ public class PostController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<PostResponse>> getPosts() {
-        List<PostResponse> postsResponse = postService.getPosts();
+    public ResponseEntity<List<PostResponse>> getPosts(
+            @RequestParam(required = false, defaultValue = "latest") String sort,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                    LocalDateTime startDate,
+            @PageableDefault(size = 10) Pageable pageable) {
+        List<PostResponse> postsResponse = postService.getPosts(sort, startDate, pageable);
         return ResponseEntity.ok(postsResponse);
     }
 

--- a/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
+++ b/backend/src/main/java/com/blog/backend/domain/repository/PostRepository.java
@@ -1,15 +1,19 @@
 package com.blog.backend.domain.repository;
 
-import java.util.List;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.blog.backend.domain.Category;
 import com.blog.backend.domain.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
     List<Post> findAllByPublicStatusTrue();
 
     Long countByUser_Id(Long userId);
@@ -27,4 +31,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Long countByCategory(Category category);
 
     Long countByCategoryAndPublicStatus(Category category, boolean b);
+
+    @Query(
+            "SELECT p FROM Post p "
+                    + "JOIN Like l ON l.post.id = p.id "
+                    + "WHERE p.publicStatus = true "
+                    + "AND l.createdAt >= :startDate "
+                    + "GROUP BY p.id "
+                    + "ORDER BY COUNT(l.id) DESC ")
+    List<Post> findPublicPostsOrderByPeriodLike(
+            @Param("startDate") LocalDateTime startDate, Pageable pageable);
 }

--- a/backend/src/main/java/com/blog/backend/service/CommentService.java
+++ b/backend/src/main/java/com/blog/backend/service/CommentService.java
@@ -50,6 +50,7 @@ public class CommentService {
                 .build();
     }
 
+    @Transactional
     public void deleteComment(Long commentId, Long userId) {
         Comment comment =
                 commentRepository

--- a/backend/src/main/java/com/blog/backend/service/PostService.java
+++ b/backend/src/main/java/com/blog/backend/service/PostService.java
@@ -1,7 +1,10 @@
 package com.blog.backend.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -191,8 +194,18 @@ public class PostService {
         return userId.equals(post.getUserId());
     }
 
-    public List<PostResponse> getPosts() {
-        List<Post> posts = postRepository.findAllByPublicStatusTrue();
+    public List<PostResponse> getPosts(String sort, LocalDateTime startDate, Pageable pageable) {
+        List<Post> posts = List.of();
+
+        if ("latest".equals(sort)) {
+            posts = postRepository.findAllByPublicStatusTrue();
+        }
+
+        if ("likes".equals(sort)) {
+            PageRequest cleanPageable =
+                    PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+            posts = postRepository.findPublicPostsOrderByPeriodLike(startDate, cleanPageable);
+        }
 
         return posts.stream()
                 .map(

--- a/backend/src/main/java/com/blog/backend/service/UserService.java
+++ b/backend/src/main/java/com/blog/backend/service/UserService.java
@@ -1,19 +1,5 @@
 package com.blog.backend.service;
 
-import com.blog.backend.domain.Post;
-import com.blog.backend.domain.User;
-import com.blog.backend.domain.repository.*;
-import com.blog.backend.dto.*;
-import com.blog.backend.exception.DuplicateEmailException;
-import com.blog.backend.exception.UserNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,6 +7,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.blog.backend.domain.Post;
+import com.blog.backend.domain.User;
+import com.blog.backend.domain.repository.*;
+import com.blog.backend.dto.*;
+import com.blog.backend.exception.DuplicateEmailException;
+import com.blog.backend.exception.UserNotFoundException;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
- 전체 글을 조회할 때 기본순과 좋아요순으로 정렬하는 기능 추가
- 좋아요 순 기능을 선택하면 시간을 일주일, 한달, 1년기준으로 선택하여 해당 기간동안의 좋아요 수를 기준으로 좋아요수가 많은 순서대로 정렬하는 기능 추가
- 팔로잉 글 목록의 경우 기본적으로 최신순으로 정력되도록 변경