### PR TITLE
refactor : Dto CommentResponse의 불필요한 필드 postId 제거

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,10 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+tasks.named('compileJava') {
+    dependsOn 'spotlessApply'
+}
+
 spotless {
     java {
         googleJavaFormat('1.22.0').aosp()

--- a/backend/src/main/java/com/blog/backend/controller/LikeController.java
+++ b/backend/src/main/java/com/blog/backend/controller/LikeController.java
@@ -1,13 +1,15 @@
 package com.blog.backend.controller;
 
-import com.blog.backend.service.LikeService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.blog.backend.service.LikeService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/blog/backend/controller/PostController.java
+++ b/backend/src/main/java/com/blog/backend/controller/PostController.java
@@ -1,8 +1,8 @@
 package com.blog.backend.controller;
 
-import com.blog.backend.dto.*;
-import com.blog.backend.service.PostService;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -10,8 +10,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import com.blog.backend.dto.*;
+import com.blog.backend.service.PostService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/posts")

--- a/backend/src/main/java/com/blog/backend/dto/CommentResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/CommentResponse.java
@@ -4,8 +4,4 @@ import lombok.Builder;
 
 @Builder
 public record CommentResponse(
-        Long commentId,
-        String profileImageUrl,
-        String author,
-        Long authorId,
-        String content) {}
+        Long commentId, String profileImageUrl, String author, Long authorId, String content) {}

--- a/backend/src/main/java/com/blog/backend/service/CommentService.java
+++ b/backend/src/main/java/com/blog/backend/service/CommentService.java
@@ -1,5 +1,10 @@
 package com.blog.backend.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.blog.backend.domain.Comment;
 import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.CommentRepository;
@@ -11,11 +16,8 @@ import com.blog.backend.dto.UpdateCommentRequest;
 import com.blog.backend.exception.AuthorOnlyException;
 import com.blog.backend.exception.CommentNotFoundException;
 import com.blog.backend.exception.UserNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/blog/backend/service/LikeService.java
+++ b/backend/src/main/java/com/blog/backend/service/LikeService.java
@@ -1,12 +1,14 @@
 package com.blog.backend.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
 import com.blog.backend.exception.AlreadyDeleteException;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/blog/backend/service/PostService.java
+++ b/backend/src/main/java/com/blog/backend/service/PostService.java
@@ -1,18 +1,20 @@
 package com.blog.backend.service;
 
-import com.blog.backend.domain.*;
-import com.blog.backend.domain.repository.*;
-import com.blog.backend.dto.*;
-import com.blog.backend.exception.*;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import com.blog.backend.domain.*;
+import com.blog.backend.domain.repository.*;
+import com.blog.backend.dto.*;
+import com.blog.backend.exception.*;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/test/java/com/blog/backend/controller/LikeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/LikeControllerIntegrationTest.java
@@ -2,7 +2,6 @@ package com.blog.backend.controller;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +43,7 @@ class LikeControllerIntegrationTest {
     }
 
     @Test
-    void shouldDeleteLikeAndReturnCount() throws Exception {
+    void shouldDeleteLikeAndReturnNoContent() throws Exception {
         User author = saveUser("author");
         User liker = saveUser("liker");
         Post post = savePost(author);
@@ -53,8 +52,7 @@ class LikeControllerIntegrationTest {
         mockMvc.perform(
                         delete("/api/likes/{postId}", post.getId())
                                 .header(AUTHORIZATION, bearer(liker.getId())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCount").value(0));
+                .andExpect(status().isNoContent());
     }
 
     @Test

--- a/backend/src/test/java/com/blog/backend/controller/PostControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/PostControllerIntegrationTest.java
@@ -179,7 +179,6 @@ class PostControllerIntegrationTest {
                                 .contentType(APPLICATION_JSON)
                                 .content("{\"content\":\"mine\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.postId").value(post.getId()))
                 .andExpect(jsonPath("$.authorId").value(author.getId()))
                 .andExpect(jsonPath("$.content").value("mine"));
     }

--- a/backend/src/test/java/com/blog/backend/service/LikeServiceTest.java
+++ b/backend/src/test/java/com/blog/backend/service/LikeServiceTest.java
@@ -1,6 +1,5 @@
 package com.blog.backend.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
-import com.blog.backend.dto.LikeResponse;
 import com.blog.backend.exception.AlreadyDeleteException;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,13 +25,10 @@ class LikeServiceTest {
     @InjectMocks private LikeService likeService;
 
     @Test
-    void deleteLikeShouldRemoveLikeAndReturnCount() {
+    void deleteLikeShouldRemoveLike() {
         when(likeRepository.existsByUser_IdAndPost_Id(2L, 1L)).thenReturn(true);
-        when(likeRepository.countByPost_Id(1L)).thenReturn(4L);
 
-        LikeResponse response = likeService.deleteLike(1L, 2L);
-
-        assertThat(response.totalCount()).isEqualTo(4L);
+        likeService.deleteLike(1L, 2L);
         verify(likeRepository).removeByUser_IdAndPost_Id(2L, 1L);
     }
 

--- a/backend/src/test/java/com/blog/backend/service/PostServiceTest.java
+++ b/backend/src/test/java/com/blog/backend/service/PostServiceTest.java
@@ -193,7 +193,6 @@ class PostServiceTest {
 
         CommentResponse response = postService.addComment(31L, new AddCommentRequest("mine"), 1L);
 
-        assertThat(response.postId()).isEqualTo(31L);
         assertThat(response.authorId()).isEqualTo(1L);
         assertThat(response.content()).isEqualTo("mine");
     }


### PR DESCRIPTION
- N+1문제 해결을 위해 얼만큼 쿼리문이 날아가는지 테이블들을 따지다 보니 불필요한 필드를 가진것을 발견하여 삭제함
- 프론트에서도 사용하지 않는 필드이기에 백엔드 코드만 수정함