### PR TITLE
feature : 테스트컨테이너를 이용하여 테스트 하도록 코드 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      APP_VERSION: build-${{ github.run_number }}
+      APP_COMMIT_SHA: ${{ github.sha }}
+      APP_BUILT_AT: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+      DEPLOY_VERSION_URL: https://hc-domain.site/api/version
 
     defaults:
       run:
@@ -42,4 +47,38 @@ jobs:
           script: |
             cd ~/my_blog_project
             git pull origin main  # 최신 코드를 땡겨옵니다. (.env는 이미 서버에 있으니 유지됨)
+            export APP_VERSION='${{ env.APP_VERSION }}'
+            export APP_COMMIT_SHA='${{ env.APP_COMMIT_SHA }}'
+            export APP_BUILT_AT='${{ env.APP_BUILT_AT }}'
+            export APP_DEPLOYED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             docker compose up -d --build backend  # 서버에 있는 .env를 사용해 빌드 및 실행!
+
+      - name: 배포 버전 검증
+        if: github.event_name == 'push'
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          url = os.environ["DEPLOY_VERSION_URL"]
+          expected_sha = os.environ["APP_COMMIT_SHA"]
+          last_payload = None
+
+          for attempt in range(30):
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as response:
+                      payload = json.loads(response.read().decode("utf-8"))
+                  last_payload = payload
+                  if payload.get("commitSha") == expected_sha:
+                      print("Deployment version verified:", payload)
+                      break
+              except Exception as exc:
+                  last_payload = {"error": str(exc)}
+              time.sleep(10)
+          else:
+              raise SystemExit(
+                  f"Deployment verification failed. expected commitSha={expected_sha}, last_response={last_payload}"
+              )
+          PY

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,7 +37,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'com.h2database:h2'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 
 
     //JWT를 라이브러리

--- a/backend/src/main/java/com/blog/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/blog/backend/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                         auth ->
                                 auth.requestMatchers("/api/auth/**")
                                         .permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/api/version")
+                                        .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/api/posts/list")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/api/posts/{postId}")

--- a/backend/src/main/java/com/blog/backend/controller/AppVersionController.java
+++ b/backend/src/main/java/com/blog/backend/controller/AppVersionController.java
@@ -1,0 +1,24 @@
+package com.blog.backend.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.blog.backend.dto.AppVersionResponse;
+import com.blog.backend.service.AppVersionService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/version")
+public class AppVersionController {
+
+    private final AppVersionService appVersionService;
+
+    @GetMapping
+    public ResponseEntity<AppVersionResponse> getVersion() {
+        return ResponseEntity.ok(appVersionService.getVersion());
+    }
+}

--- a/backend/src/main/java/com/blog/backend/dto/AppVersionResponse.java
+++ b/backend/src/main/java/com/blog/backend/dto/AppVersionResponse.java
@@ -1,0 +1,7 @@
+package com.blog.backend.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AppVersionResponse(
+        String appName, String version, String commitSha, String builtAt, String deployedAt) {}

--- a/backend/src/main/java/com/blog/backend/service/AppVersionService.java
+++ b/backend/src/main/java/com/blog/backend/service/AppVersionService.java
@@ -1,0 +1,35 @@
+package com.blog.backend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.blog.backend.dto.AppVersionResponse;
+
+@Service
+public class AppVersionService {
+
+    @Value("${app.meta.name:my-blog-backend}")
+    private String appName;
+
+    @Value("${app.meta.version:unknown}")
+    private String version;
+
+    @Value("${app.meta.commit-sha:unknown}")
+    private String commitSha;
+
+    @Value("${app.meta.built-at:unknown}")
+    private String builtAt;
+
+    @Value("${app.meta.deployed-at:unknown}")
+    private String deployedAt;
+
+    public AppVersionResponse getVersion() {
+        return AppVersionResponse.builder()
+                .appName(appName)
+                .version(version)
+                .commitSha(commitSha)
+                .builtAt(builtAt)
+                .deployedAt(deployedAt)
+                .build();
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -13,6 +13,12 @@ server:
 app:
   cors:
     allowed-origins: https://blog-front-temp.vercel.app,https://hc-domain.site,http://localhost:5173
+  meta:
+    name: my-blog-backend
+    version: ${APP_VERSION:unknown}
+    commit-sha: ${APP_COMMIT_SHA:unknown}
+    built-at: ${APP_BUILT_AT:unknown}
+    deployed-at: ${APP_DEPLOYED_AT:unknown}
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/backend/src/test/java/com/blog/backend/controller/AppVersionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/AppVersionControllerIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.blog.backend.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.blog.backend.support.MySqlContainerTestSupport;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AppVersionControllerIntegrationTest extends MySqlContainerTestSupport {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    void shouldExposeApplicationVersionMetadataWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/api/version"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.appName").value("my-blog-backend-test"))
+                .andExpect(jsonPath("$.version").value("test-version"))
+                .andExpect(jsonPath("$.commitSha").value("test-commit"))
+                .andExpect(jsonPath("$.builtAt").value("2026-04-21T00:00:00Z"))
+                .andExpect(jsonPath("$.deployedAt").value("2026-04-21T00:01:00Z"));
+    }
+}

--- a/backend/src/test/java/com/blog/backend/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/AuthControllerIntegrationTest.java
@@ -19,11 +19,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class AuthControllerIntegrationTest {
+class AuthControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private UserRepository userRepository;

--- a/backend/src/test/java/com/blog/backend/controller/CategoryControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/CategoryControllerIntegrationTest.java
@@ -19,12 +19,13 @@ import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.CategoryRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class CategoryControllerIntegrationTest {
+class CategoryControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;

--- a/backend/src/test/java/com/blog/backend/controller/CommentControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/CommentControllerIntegrationTest.java
@@ -26,12 +26,13 @@ import com.blog.backend.domain.repository.CategoryRepository;
 import com.blog.backend.domain.repository.CommentRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class CommentControllerIntegrationTest {
+class CommentControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;

--- a/backend/src/test/java/com/blog/backend/controller/FollowControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/FollowControllerIntegrationTest.java
@@ -18,12 +18,13 @@ import com.blog.backend.domain.Follow;
 import com.blog.backend.domain.User;
 import com.blog.backend.domain.repository.FollowRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class FollowControllerIntegrationTest {
+class FollowControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;

--- a/backend/src/test/java/com/blog/backend/controller/LikeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/LikeControllerIntegrationTest.java
@@ -20,12 +20,13 @@ import com.blog.backend.domain.repository.CategoryRepository;
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class LikeControllerIntegrationTest {
+class LikeControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;

--- a/backend/src/test/java/com/blog/backend/controller/PostControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/PostControllerIntegrationTest.java
@@ -1,9 +1,12 @@
 package com.blog.backend.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -26,12 +29,13 @@ import com.blog.backend.domain.repository.CommentRepository;
 import com.blog.backend.domain.repository.LikeRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class PostControllerIntegrationTest {
+class PostControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;
@@ -62,6 +66,66 @@ class PostControllerIntegrationTest {
                 .andExpect(jsonPath("$.authorId").value(author.getId()))
                 .andExpect(jsonPath("$.liked").value(false))
                 .andExpect(jsonPath("$.categoryName").value("daily"));
+    }
+
+    @Test
+    void shouldAddPostForAuthenticatedUser() throws Exception {
+        User author = saveUser("author");
+
+        mockMvc.perform(
+                        post("/api/posts")
+                                .header(AUTHORIZATION, bearer(author.getId()))
+                                .contentType(APPLICATION_JSON)
+                                .content(
+                                        """
+                                        {"categoryName":"daily","title":"new title","content":"new content","publicStatus":true}
+                                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("new title"))
+                .andExpect(jsonPath("$.authorId").value(author.getId()))
+                .andExpect(jsonPath("$.publicStatus").value(true))
+                .andExpect(jsonPath("$.likeCount").value(0));
+
+        assertThat(postRepository.findAll()).hasSize(1);
+        assertThat(categoryRepository.findByNameAndUser_Id("daily", author.getId())).isPresent();
+    }
+
+    @Test
+    void shouldUpdatePostAndMoveCategory() throws Exception {
+        User author = saveUser("author");
+        Category category = saveCategory(author, "daily", 1L);
+        Post post = savePost(author, category, true);
+
+        mockMvc.perform(
+                        put("/api/posts/{postId}", post.getId())
+                                .header(AUTHORIZATION, bearer(author.getId()))
+                                .contentType(APPLICATION_JSON)
+                                .content(
+                                        """
+                                        {"categoryName":"updated","title":"updated title","content":"updated content","publicStatus":false}
+                                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("updated title"))
+                .andExpect(jsonPath("$.content").value("updated content"))
+                .andExpect(jsonPath("$.publicStatus").value(false));
+
+        assertThat(categoryRepository.findByNameAndUser_Id("daily", author.getId())).isEmpty();
+        assertThat(categoryRepository.findByNameAndUser_Id("updated", author.getId())).isPresent();
+    }
+
+    @Test
+    void shouldDeleteOwnPostAndRemoveEmptyCategory() throws Exception {
+        User author = saveUser("author");
+        Category category = saveCategory(author, "daily", 1L);
+        Post post = savePost(author, category, true);
+
+        mockMvc.perform(
+                        delete("/api/posts/{postId}", post.getId())
+                                .header(AUTHORIZATION, bearer(author.getId())))
+                .andExpect(status().isNoContent());
+
+        assertThat(postRepository.findById(post.getId())).isEmpty();
+        assertThat(categoryRepository.findById(category.getId())).isEmpty();
     }
 
     @Test
@@ -174,6 +238,22 @@ class PostControllerIntegrationTest {
                 .andExpect(
                         jsonPath("$.message")
                                 .value(org.hamcrest.Matchers.containsString("작성자만 접근")));
+    }
+
+    @Test
+    void shouldReturnLikeUsersForAuthor() throws Exception {
+        User author = saveUser("author");
+        User reader = saveUser("reader");
+        Category category = saveCategory(author, "likes", 1L);
+        Post post = savePost(author, category, true);
+        likeRepository.saveAndFlush(Like.builder().post(post).user(reader).build());
+
+        mockMvc.perform(
+                        get("/api/posts/{postId}/likes", post.getId())
+                                .header(AUTHORIZATION, bearer(author.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].username").value("reader"));
     }
 
     @Test

--- a/backend/src/test/java/com/blog/backend/controller/UserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/blog/backend/controller/UserControllerIntegrationTest.java
@@ -25,12 +25,13 @@ import com.blog.backend.domain.repository.CategoryRepository;
 import com.blog.backend.domain.repository.FollowRepository;
 import com.blog.backend.domain.repository.PostRepository;
 import com.blog.backend.domain.repository.UserRepository;
+import com.blog.backend.support.MySqlContainerTestSupport;
 import com.blog.backend.utils.JwtUtil;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class UserControllerIntegrationTest {
+class UserControllerIntegrationTest extends MySqlContainerTestSupport {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private JwtUtil jwtUtil;
@@ -63,6 +64,25 @@ class UserControllerIntegrationTest {
     }
 
     @Test
+    void shouldReturnProfileExtraForFollower() throws Exception {
+        User author = saveUser("author", "author@test.com");
+        User follower = saveUser("follower", "follower@test.com");
+        Category category = saveCategory(author, "daily", 2L);
+        savePost(author, category, "public-title", true);
+        savePost(author, category, "private-title", false);
+        followRepository.saveAndFlush(
+                Follow.builder().follower(follower).following(author).build());
+
+        mockMvc.perform(
+                        get("/api/users/profile/extra/{userId}", author.getId())
+                                .header(AUTHORIZATION, bearer(follower.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postAllCount").value(2))
+                .andExpect(jsonPath("$.postPublicCount").value(1))
+                .andExpect(jsonPath("$.isFollowing").value(true));
+    }
+
+    @Test
     void shouldReturnOnlyPublicUserPostsForGuest() throws Exception {
         User user = saveUser("author", "author@test.com");
         Category category = saveCategory(user, "daily", 2L);
@@ -88,6 +108,32 @@ class UserControllerIntegrationTest {
                                 .header(AUTHORIZATION, bearer(user.getId())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void shouldReturnFollowers() throws Exception {
+        User author = saveUser("author", "author@test.com");
+        User follower = saveUser("follower", "follower@test.com");
+        followRepository.saveAndFlush(
+                Follow.builder().follower(follower).following(author).build());
+
+        mockMvc.perform(get("/api/users/{userId}/followers", author.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].username").value("follower"));
+    }
+
+    @Test
+    void shouldReturnFollowings() throws Exception {
+        User author = saveUser("author", "author@test.com");
+        User following = saveUser("following", "following@test.com");
+        followRepository.saveAndFlush(
+                Follow.builder().follower(author).following(following).build());
+
+        mockMvc.perform(get("/api/users/{userId}/followings", author.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].username").value("following"));
     }
 
     @Test

--- a/backend/src/test/java/com/blog/backend/support/MySqlContainerTestSupport.java
+++ b/backend/src/test/java/com/blog/backend/support/MySqlContainerTestSupport.java
@@ -1,0 +1,27 @@
+package com.blog.backend.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+public abstract class MySqlContainerTestSupport {
+
+    // Keep one MySQL container for the whole test JVM to avoid repeated startups.
+    private static final MySQLContainer<?> MYSQL_CONTAINER =
+            new MySQLContainer<>("mysql:8.0.36")
+                    .withDatabaseName("blog_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static {
+        MYSQL_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL_CONTAINER::getDriverClassName);
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,16 +1,14 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL # MySQL 모드로 호환성 높임
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
   jpa:
     hibernate:
-      ddl-auto: create-drop
-    show-sql: true # 테스트 시 쿼리 로그 확인을 위해 추가
+      ddl-auto: create
+    show-sql: true
 
-  servlet: # 테스트 중 파일 업로드 API 호출 시 에러 방지
+  test:
+    database:
+      replace: none
+
+  servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 50MB
@@ -19,6 +17,12 @@ app:
   cors:
     allowed-origins:
       - http://localhost:5173
+  meta:
+    name: my-blog-backend-test
+    version: test-version
+    commit-sha: test-commit
+    built-at: 2026-04-21T00:00:00Z
+    deployed-at: 2026-04-21T00:01:00Z
 
 jwt:
   secret: "testsecretkeytestsecretkeytestsecretkey123"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - APP_VERSION=${APP_VERSION:-unknown}
+      - APP_COMMIT_SHA=${APP_COMMIT_SHA:-unknown}
+      - APP_BUILT_AT=${APP_BUILT_AT:-unknown}
+      - APP_DEPLOYED_AT=${APP_DEPLOYED_AT:-unknown}
     volumes:
       - ./img_data:/app/img_data
 


### PR DESCRIPTION
# feature : 테스트컨테이너를 이용하여 테스트 하도록 코드 수정
Testcontainers 기반 MySQL 테스트 전환 및 배포 버전 검증 엔드포인트 추가

## 작업 배경
- 기존 테스트 환경은 H2 기반 또는 mock 중심으로 동작하고 있어, 실제 운영 DB(MySQL)와의 차이로 인해 CI 환경에서 재현되지 않는 문제가 발생할 수 있었습니다.
- 배포 이후 현재 서버에 최신 버전이 실제로 반영되었는지 GitHub Actions 단계에서 확인할 수 있는 수단이 필요했습니다.

## 주요 변경 사항
### 1. 테스트 환경을 H2에서 Testcontainers 기반 MySQL로 전환
- `backend/build.gradle`
  - `org.testcontainers:junit-jupiter`
  - `org.testcontainers:mysql`
  의존성 추가
- `backend/src/test/resources/application-test.yml`
  - 임베디드 H2 설정 제거
  - `spring.test.database.replace=none` 적용
  - 테스트 시 스키마 생성 전략 정리
- `backend/src/test/java/com/blog/backend/support/MySqlContainerTestSupport.java`
  - 테스트 전용 MySQL 컨테이너 공통 설정 추가
  - 통합 테스트에서 동일 컨테이너를 재사용하도록 구성

### 2. 통합 테스트 보강
- 누락되어 있던 주요 컨트롤러 테스트 추가
  - 게시글 생성 / 수정 / 삭제
  - 게시글 좋아요 사용자 조회
  - 사용자 profile extra 조회
  - follower / following 조회
  - 버전 정보 조회 엔드포인트 테스트
- 기존 컨트롤러 통합 테스트를 모두 Testcontainers 기반으로 전환

### 3. 배포 버전 확인 엔드포인트 추가
- `GET /api/version` 엔드포인트 추가
- 응답 정보
  - `appName`
  - `version`
  - `commitSha`
  - `builtAt`
  - `deployedAt`
- 비인증으로 조회 가능하도록 Security 설정 반영

### 4. GitHub Actions 배포 검증 단계 추가
- CI/CD 워크플로우에서 아래 메타데이터를 환경변수로 주입하도록 수정
  - `APP_VERSION`
  - `APP_COMMIT_SHA`
  - `APP_BUILT_AT`
  - `APP_DEPLOYED_AT`
- 배포 후 `/api/version` 엔드포인트를 호출하여
  - 현재 배포된 `commitSha`가
  - GitHub Actions에서 배포한 `github.sha`와 일치하는지 검증하도록 구성

## 기대 효과
- CI 환경에서도 운영 DB와 동일한 MySQL 계열 환경에서 테스트 가능
- H2와 MySQL 간 차이로 인한 오탐/미탐 감소
- PR 머지 후 실제 최신 버전이 서버에 반영되었는지 자동 검증 가능
- 배포 상태를 API로 빠르게 확인 가능

## 테스트
- `./gradlew test`
- 결과: 전체 테스트 통과

## 확인 포인트
- GitHub Actions 러너에서 Docker 사용 가능해야 함
- 배포 검증 URL이 실제 운영 도메인과 일치해야 함
- 서버에서 `docker compose up -d --build backend` 실행 시 환경변수가 정상 반영되어야 함

## 참고
- PR 머지 후 `main` 브랜치 push 이벤트로 CI/CD가 동작
- 배포 완료 후 GitHub Actions 마지막 단계에서 `/api/version` 응답의 `commitSha`를 검증
